### PR TITLE
travis: Fix Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: sh
 sudo: false
 dist: trusty
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
 env:
   - USING_ZSH_VERSION="zsh-5.0.8"
   - USING_ZSH_VERSION="zsh-5.1.1"


### PR DESCRIPTION
Accoding to https://github.com/koalaman/shellcheck#travis-ci, ShellCheck is now officially included in Travis-CI default image.